### PR TITLE
use python2 for wrap.py

### DIFF
--- a/nvtx_pmpi_wrappers/wrap/wrap.py
+++ b/nvtx_pmpi_wrappers/wrap/wrap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #################################################################################################
 # Copyright (c) 2010, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory


### PR DESCRIPTION
Not python3 compatible, and now most systems python points
at python3.